### PR TITLE
Add quote for folder id env

### DIFF
--- a/scalar-workflow/charts/web/templates/web/deployment.yaml
+++ b/scalar-workflow/charts/web/templates/web/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           - name: AWS_USER_POOLS_WEB_CLIENT_ID
             value: {{ .Values.web.aws.awsUserPoolsWebClientId }}
           - name: ROOT_WORKAREA_ID
-            value: {{ .Values.web.storage.rootWorkareaId }}
+            value: {{ .Values.web.storage.rootWorkareaId | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Since the folder id is a number when using box storage, then without quoting the folder id the deployment is failed. This PR fixes this bug. Please take a look.