### PR TITLE
Add env for web port

### DIFF
--- a/scalar-workflow/charts/web/templates/web/deployment.yaml
+++ b/scalar-workflow/charts/web/templates/web/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               containerPort: {{ .Values.web.port }}
               protocol: TCP
           env:
+          - name: SCALARFLOW_WEB_SERVER_PORT
+            value: {{ .Values.web.port | quote }}
           - name: SCALARFLOW_API_URL
             value: {{ .Values.web.wfApi }}
           - name: SCALARFLOW_WEB_AWS_PROJECT_REGION


### PR DESCRIPTION
We have an environment variable to config web server port, so we have to add it here in the deployment manifest.