### PR TITLE
Adding environment vars for scalardb and box config

### DIFF
--- a/scalarflow/charts/api/templates/api/deployment.yaml
+++ b/scalarflow/charts/api/templates/api/deployment.yaml
@@ -48,6 +48,12 @@ spec:
             - name: SCALARDB__CONFIG
               value: "{{ .Values.api.configMouthPath }}/{{ .Values.api.scalardb.config }}"
             {{- end }}
+            - name: SCALARDB__NAMESPACE
+              value: {{ .Values.api.scalardb.namespace | quote }}
+            - name: SCALARDB__CONTACT_POINTS
+              value: {{ .Values.api.scalardb.contactPoints | quote }}
+            - name: SCALARDB__CONTACT_PORT
+              value: {{ .Values.api.scalardb.contactPort | quote }}
             - name: APP__STORAGE__TEMPLATE_ROOT_FOLDER_ID
               value: {{ .Values.api.app.storage.templateRootFolderId | quote }}
             - name: APP__STORAGE__WORKFLOW_ROOT_FOLDER_ID
@@ -89,6 +95,33 @@ spec:
             {{- end }}
             - name: STORAGE__BOX__GROUP_ID
               value: {{ .Values.api.storage.box.groupId | quote }}
+            - name: STORAGE__BOX__CLIENT_ID
+              value: {{ .Values.api.storage.box.clientId | quote }}
+            {{- if .Values.api.storage.box.clientSecret }}
+            - name: STORAGE__BOX__CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: STORAGE__BOX__CLIENT_SECRET
+                  name: {{ .Chart.Name }}-secret
+            {{- end }}
+            - name: STORAGE__BOX__PUBLIC_KEY_ID
+              value: {{ .Values.api.storage.box.publicKeyId | quote }}
+            {{- if .Values.api.storage.box.privateKey }}
+            - name: STORAGE__BOX__PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: STORAGE__BOX__PRIVATE_KEY
+                  name: {{ .Chart.Name }}-secret
+            {{- end }}
+            {{- if .Values.api.storage.box.passphrase }}
+            - name: STORAGE__BOX__PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  key: STORAGE__BOX__PASSPHRASE
+                  name: {{ .Chart.Name }}-secret
+            {{- end }}
+            - name: STORAGE__BOX__ENTERPRISE_ID
+              value: {{ .Values.api.storage.box.enterpriseId | quote }}
             - name: STORAGE__JCLOUDS__ENABLED
               value: {{ .Values.api.storage.jclouds.enabled | quote }}
             - name: STORAGE__JCLOUDS__CONTAINER

--- a/scalarflow/charts/api/templates/api/secret.yaml
+++ b/scalarflow/charts/api/templates/api/secret.yaml
@@ -21,6 +21,18 @@ data:
   APP__ADMIN_USER__PASSWORD: |-
 {{ .Values.api.app.adminUser.password | b64enc  | indent 4 }}
   {{- end }}
+  {{- if .Values.api.storage.box.clientSecret }}
+  STORAGE__BOX__CLIENT_SECRET: |-
+{{ .Values.api.storage.box.clientSecret | b64enc  | indent 4 }}
+  {{- end }}
+  {{- if .Values.api.storage.box.privateKey }}
+  STORAGE__BOX__PRIVATE_KEY: |-
+{{ .Values.api.storage.box.privateKey | b64enc  | indent 4 }}
+  {{- end }}
+  {{- if .Values.api.storage.box.passphrase }}
+  STORAGE__BOX__PASSPHRASE: |-
+{{ .Values.api.storage.box.passphrase | b64enc  | indent 4 }}
+  {{- end }}
   {{- if .Values.api.storage.jclouds.identity }}
   STORAGE__JCLOUDS__IDENTITY: |-
 {{ .Values.api.storage.jclouds.identity | b64enc  | indent 4 }}

--- a/scalarflow/charts/api/templates/schemaloader/job.yaml
+++ b/scalarflow/charts/api/templates/schemaloader/job.yaml
@@ -32,11 +32,23 @@ spec:
           image: "{{ .Values.api.schemaLoader.image.repository }}:{{ .Values.api.schemaLoader.image.tag | default "latest" }}"
           imagePullPolicy: {{ .Values.api.schemaLoader.image.pullPolicy }}
           env:
-          - name: CONFIG_FILE
-            value: "{{ .Values.api.configMouthPath }}/{{ .Values.api.scalardb.config }}"
+            {{- if .Values.api.scalardb.configData }}
+            - name: CONFIG_FILE
+              value: "{{ .Values.api.configMouthPath }}/{{ .Values.api.scalardb.config }}"
+            {{- end }}
+            - name: SCALAR_DB_CONTACT_POINTS
+              value: {{ .Values.api.scalardb.contactPoints | quote }}
+            - name: SCALAR_DB_CONTACT_PORT
+              value: {{ .Values.api.scalardb.contactPort | quote }}
+            - name: SCALAR_DB_STORAGE
+              value: {{ .Values.api.scalardb.storage | quote }}
+            - name: SCALAR_DB_TRANSACTION_MANAGER
+              value: {{ .Values.api.scalardb.transactionManager | quote }}
           volumeMounts:
-          - name: {{ .Chart.Name }}-secret-volume
-            mountPath: {{ .Values.api.configMouthPath }}
+            {{- if .Values.api.scalardb.configData }}
+            - name: {{ .Chart.Name }}-secret-volume
+              mountPath: {{ .Values.api.configMouthPath }}
+            {{- end }}
           {{- if .Values.api.schemaLoader.args }}
           args:
           {{- range .Values.api.schemaLoader.args }}
@@ -44,9 +56,11 @@ spec:
           {{- end }}
           {{- end }}
       volumes:
+        {{- if .Values.api.scalardb.configData }}
         - name: {{ .Chart.Name }}-secret-volume
           secret:
             secretName: {{ .Chart.Name }}-secret
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/scalarflow/charts/api/values.yaml
+++ b/scalarflow/charts/api/values.yaml
@@ -44,6 +44,12 @@ api:
   scalardb:
     config: scalardb.properties
     configData: ""
+    # In the case the properties file is not used, then the configuration can be done via bellow configs
+    namespace: scalarflow
+    contactPoint: "scalardb-server-envoy"
+    contactPort: 60051
+    storage: grpc
+    transactionManager: grpc
 
   app:
     storage:
@@ -71,6 +77,13 @@ api:
       config: box-config.json
       configData: ""
       groupId: ""
+      # In the case the config file is not used, please using bellow configs
+      clientId: ""
+      clientSecret: ""
+      publicKeyId: ""
+      privateKey: ""
+      passphrase: ""
+      enterpriseId: ""
     jclouds:
       enabled: false
       container: ""


### PR DESCRIPTION
Since our `scalarflow-schema-loader` supports the env vars already so we can migrate the helm chart to full env vars configurable. This PR is made to update that. PTAL! Thank you!