### PR TITLE
Adding spring JPA configuration to api chart

### DIFF
--- a/scalarflow/charts/api/templates/api/deployment.yaml
+++ b/scalarflow/charts/api/templates/api/deployment.yaml
@@ -42,6 +42,27 @@ spec:
           env:
             - name: SPRING__SECURITY__OAUTH2__RESOURCESERVER__JWT__ISSUER_URI
               value: {{ .Values.api.spring.security.oauth2.resourceServer.jwt.issuerUri | quote }}
+            {{- if .Values.api.spring.datasource.url }}
+            - name: SPRING__DATASOURCE__URL
+              valueFrom:
+                secretKeyRef:
+                  key: SPRING__DATASOURCE__URL
+                  name: {{ .Chart.Name }}-secret
+            {{- end }}
+            {{- if .Values.api.spring.datasource.username }}
+            - name: SPRING__DATASOURCE__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: SPRING__DATASOURCE__USERNAME
+                  name: {{ .Chart.Name }}-secret
+            {{- end }}
+            {{- if .Values.api.spring.datasource.password }}
+            - name: SPRING__DATASOURCE__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: SPRING__DATASOURCE__PASSWORD
+                  name: {{ .Chart.Name }}-secret
+            {{- end }}
             - name: SERVER__PORT
               value: {{ .Values.api.server.port | quote }}
             {{- if .Values.api.scalardb.configData }}

--- a/scalarflow/charts/api/templates/api/secret.yaml
+++ b/scalarflow/charts/api/templates/api/secret.yaml
@@ -5,6 +5,18 @@ metadata:
   name: {{ .Chart.Name }}-secret
   namespace: {{ .Release.Namespace }}
 data:
+  {{- if .Values.api.spring.datasource.url }}
+  SPRING__DATASOURCE__URL: |-
+{{ .Values.api.spring.datasource.url | b64enc  | indent 4 }}
+  {{- end }}
+  {{- if .Values.api.spring.datasource.username }}
+  SPRING__DATASOURCE__USERNAME: |-
+{{ .Values.api.spring.datasource.username | b64enc  | indent 4 }}
+  {{- end }}
+  {{- if .Values.api.spring.datasource.password }}
+  SPRING__DATASOURCE__PASSWORD: |-
+{{ .Values.api.spring.datasource.password | b64enc  | indent 4 }}
+  {{- end }}
   {{- if .Values.api.springBootConfig.data }}
   {{.Values.api.springBootConfig.name }}: |-
 {{ .Values.api.springBootConfig.data | b64enc  | indent 4 }}

--- a/scalarflow/charts/api/values.yaml
+++ b/scalarflow/charts/api/values.yaml
@@ -37,6 +37,10 @@ api:
         resourceServer:
           jwt:
             issuerUri: ""
+    datasource:
+      url: ""
+      username: ""
+      password: ""
 
   server:
     port: 8080


### PR DESCRIPTION
Since we support JDBC JPA in the API, so we introduce these configs in the Helm Chart as well. Please take a look when you have a chance.