### PR TITLE
Adding github action for release charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,13 @@ name: Release Charts
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
 
 jobs:
-  release:
+  release-scalarflow-charts:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: scalarflow/charts
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - 'main'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
@@ -32,4 +30,5 @@ jobs:
           charts_dir: scalarflow/charts
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CR_SKIP_EXISTING: true
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-Helm chart for the ScalarFlow project
+# Scalar Helm Charts Repository
+
+[![Release Charts](https://github.com/scalar-labs/scalarflow-helm-charts/actions/workflows/release.yml/badge.svg)](https://github.com/scalar-labs/scalarflow-helm-charts/actions/workflows/release.yml)
+
+
+This directory contains the following helm charts.
+* [ScalarFlow API](./scalarflow/charts/api/)
+* [ScalarFlow Web](./scalarflow/charts/web/)
+
+
+## Prerequisites
+
+* Helm 3.5+
+
+## Supported Kubernetes versions
+
+* 1.25.x, 1.24.x, 1.23.x, 1.22.x, 1.21.x
+
+## Usage
+
+### Helm
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+helm repo add scalarflow https://scalar-labs.github.io/scalarflow-helm-charts
+```
+
+You can then run `helm search repo scalarflow` to see the ScalarFlow charts.  
+Also, you can see all the versions by `helm search repo scalarflow --versions` command.
+
+
+## Contributing
+
+This repo is mainly maintained by the Scalar Engineering Team, but of course we appreciate any help.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ This directory contains the following helm charts.
 
 * Helm 3.5+
 
-## Supported Kubernetes versions
-
-* 1.25.x, 1.24.x, 1.23.x, 1.22.x, 1.21.x
-
 ## Usage
 
 ### Helm

--- a/scalarflow/charts/api/Chart.yaml
+++ b/scalarflow/charts/api/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: "1.0.0-beta"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.0.0"

--- a/scalarflow/charts/api/Chart.yaml
+++ b/scalarflow/charts/api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.0-beta"
+version: "0.1.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/scalarflow/charts/web/Chart.yaml
+++ b/scalarflow/charts/web/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: "1.0.0-beta"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.0.0"

--- a/scalarflow/charts/web/Chart.yaml
+++ b/scalarflow/charts/web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.0-beta"
+version: "0.1.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This PR adds a release github workflow for releasing our ScalarFlow Helm Charts and updating the chart `index.yaml` in the `gh-pages` branch.
A readme document is also added.
Currently, the workflow will be triggered if we push a commit to the main branch or when creating a tag from a branch (for example a release branch)
Our current ScalarFlow Helm Chart GitHub page is https://scalar-labs.github.io/scalarflow-helm-charts
Once this PR is merged, the readme documentation will be added to the `gh-pages` as well.
Please take a look when you have a chance.