### PR TITLE
Fixing wrong name in the contacts points of scalardb config

### DIFF
--- a/scalarflow/charts/api/values.yaml
+++ b/scalarflow/charts/api/values.yaml
@@ -50,7 +50,7 @@ api:
     configData: ""
     # In the case the properties file is not used, then the configuration can be done via bellow configs
     namespace: scalarflow
-    contactPoint: "scalardb-server-envoy"
+    contactPoints: "scalardb-server-envoy"
     contactPort: 60051
     username: ""
     password: ""


### PR DESCRIPTION
The default value name of ScalarDB contact points does not match the actual one used in the templates, so this PR was made to fix it. PTAL. Thank you.