### PR TITLE
Make schemaLoader optional in the API chart

### DIFF
--- a/scalarflow/charts/api/templates/schemaloader/job.yaml
+++ b/scalarflow/charts/api/templates/schemaloader/job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.schemaLoader.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -60,3 +61,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/scalarflow/charts/api/values.schema.json
+++ b/scalarflow/charts/api/values.schema.json
@@ -190,6 +190,9 @@
         "args": {
           "type": "array"
         },
+        "enabled": {
+          "type": "boolean"
+        },
         "env": {
           "type": "array",
           "items": {

--- a/scalarflow/charts/api/values.yaml
+++ b/scalarflow/charts/api/values.yaml
@@ -106,6 +106,7 @@ api:
 
 # Schema Loader configuration
 schemaLoader:
+  enabled: true
   image:
     repository: ghcr.io/scalar-labs/scalarflow-schema-loader
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Add `enabled` flag to schemaLoader configuration in the API chart
- Default value is `true` to maintain backward compatibility
- Allows users to disable the schema loader Job when not needed (e.g., when schema is already loaded)

## Test plan
- [ ] Run `helm template` with default values - schemaLoader Job should be rendered
- [ ] Run `helm template --set schemaLoader.enabled=false` - schemaLoader Job should NOT be rendered
- [ ] Run `helm lint` - should pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)