### PR TITLE
Make schemaLoader optional in the API chart

### DIFF
--- a/scalarflow/charts/api/templates/schemaloader/job.yaml
+++ b/scalarflow/charts/api/templates/schemaloader/job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.schemaLoader.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -60,3 +61,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/scalarflow/charts/api/templates/schemaloader/job.yaml
+++ b/scalarflow/charts/api/templates/schemaloader/job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.schemaLoader.enabled }}
+{{- if and .Values.schemaLoader .Values.schemaLoader.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/scalarflow/charts/api/values.schema.json
+++ b/scalarflow/charts/api/values.schema.json
@@ -190,6 +190,9 @@
         "args": {
           "type": "array"
         },
+        "enabled": {
+          "type": "boolean"
+        },
         "env": {
           "type": "array",
           "items": {

--- a/scalarflow/charts/api/values.yaml
+++ b/scalarflow/charts/api/values.yaml
@@ -106,6 +106,7 @@ api:
 
 # Schema Loader configuration
 schemaLoader:
+  # -- Whether to enable the schema loader Job.
   enabled: true
   image:
     repository: ghcr.io/scalar-labs/scalarflow-schema-loader

--- a/scalarflow/charts/api/values.yaml
+++ b/scalarflow/charts/api/values.yaml
@@ -106,6 +106,7 @@ api:
 
 # Schema Loader configuration
 schemaLoader:
+  enabled: true
   image:
     repository: ghcr.io/scalar-labs/scalarflow-schema-loader
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

The schemaLoader Job runs on every Helm install/upgrade, but in some scenarios users may want to skip schema loading (e.g., when the schema is already loaded or managed externally). This PR adds an `enabled` flag to make the schemaLoader optional.

## Related issues and/or PRs

N/A

## Changes made

- Added `enabled: true` field to the `schemaLoader` section in `values.yaml`
- Added `enabled` boolean property to the schemaLoader schema in `values.schema.json`
- Wrapped the schemaLoader Job template with a conditional `{{- if .Values.schemaLoader.enabled }}`

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Verification steps:
- `helm template` with default values renders the schemaLoader Job
- `helm template --set schemaLoader.enabled=false` does not render the schemaLoader Job
- `helm lint` passes validation

## Release notes

Added an `enabled` flag to the schemaLoader configuration in the API chart, allowing users to optionally disable the schema loader Job.